### PR TITLE
change pytorch cuda function's argument to fit with Python < 3.7 also

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ def train_epoch(epoch, data_loader, model, criterion, optimizer, opt,
         data_time.update(time.time() - end_time)
 
         if not opt.no_cuda:
-            targets = targets.cuda(async=True)
+            targets = targets.cuda(non_blocking=True)
         inputs = Variable(inputs)
         targets = Variable(targets)
         #pdb.set_trace()

--- a/validation.py
+++ b/validation.py
@@ -23,7 +23,7 @@ def val_epoch(epoch, data_loader, model, criterion, opt, logger):
         data_time.update(time.time() - end_time)
 
         if not opt.no_cuda:
-            targets = targets.cuda(async=True)
+            targets = targets.cuda(non_blocking=True)
         with torch.no_grad():
             inputs = Variable(inputs)
             targets = Variable(targets)


### PR DESCRIPTION
Hi.

`targets = targets.cuda(async=True)` this Pytorch code doesn't work because of python version.
I found that async is now a reserved word in Python >= 3.7 so use non_blocking instead and non_blocking also can use Python < 3.7 also.
Then, I think that the code with non_blocking is better. Please check it.

Thanks.