### PR TITLE
Fix Spatial Transforms (MultiScaleCornerCrop)

### DIFF
--- a/spatial_transforms.py
+++ b/spatial_transforms.py
@@ -336,7 +336,7 @@ class MultiScaleCornerCrop(object):
         self.scale = self.scales[random.randint(0, len(self.scales) - 1)]
         self.crop_position = self.crop_positions[random.randint(
             0,
-            len(self.scales) - 1)]
+            len(self.crop_positions) - 1)]
 
 
 class MultiScaleRandomCrop(object):


### PR DESCRIPTION
The random list size for self.crop_position in the randomize_parameters function was incorrectly set to the size of self.scale.